### PR TITLE
Update target to Net 6.0 and update package versions

### DIFF
--- a/Goodbye.WordPress.CommandLineTool/Goodbye.WordPress.CommandLineTool.csproj
+++ b/Goodbye.WordPress.CommandLineTool/Goodbye.WordPress.CommandLineTool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 </Project>

--- a/Goodbye.WordPress/Goodbye.WordPress.csproj
+++ b/Goodbye.WordPress/Goodbye.WordPress.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ReverseMarkdown" Version="3.12.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="SharpYaml" Version="1.6.6" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="MySqlConnector" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="ReverseMarkdown" Version="3.20.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1-dev-00879" />
+    <PackageReference Include="SharpYaml" Version="1.8.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Set Net 6.0 as target
Update nuget package versions as well

## Builds
### Goodbye.WordPress

```plain
$ dotnet build
Microsoft (R) Build Engine version 17.0.0-preview-21501-01+bbcce1dff for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  PackageVersion: 0.0.0
  Goodbye.WordPress -> D:\git_ws\wordpress-export\Goodbye.WordPress\bin\Debug\net6.0\Goodbye.WordPress.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.11
```

### CommandLineTool
```plain
$ dotnet build
Microsoft (R) Build Engine version 17.0.0-preview-21501-01+bbcce1dff for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  PackageVersion: 0.0.0
  Goodbye.WordPress -> D:\git_ws\wordpress-export\Goodbye.WordPress\bin\Debug\net6.0\Goodbye.WordPress.dll
  PackageVersion: 0.0.0
  Goodbye.WordPress.CommandLineTool -> D:\git_ws\wordpress-export\Goodbye.WordPress.CommandLineTool\bin\Debug\net6.0\Goodbye.WordPress.CommandLineTool.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.57

$ dotnet run
error: no WordPress MySQL connection options or JSON input file provided

Goodbye Wordpress v0.0.0
Copyright 2020 Aaron Bockover
https://github.com/abock/goodbye-wordpress

usage: goodbye-wordpress [OPTIONS] [JSON_INPUT_FILE]

Options:

  -?, --help                 Show this help
      --version              Show version
  -v, --verbose              Use verbose logging
  -q, --quiet                Use quiet logging (errors only); synonym for -v-

Post Options:

  -o, --output-dir=VALUE     Set the output directory for posts and images
      --format=FORMAT        Output FORMAT: markdown | html | raw
      --serialize-json=FILE  Serialize the entire post set to FILE

MySQL Options:

  -h, --host=VALUE           Connect to host
  -P, --port=VALUE           Connect through port
  -u, --user=VALUE           User for login
  -p, --password=VALUE       Password to use
  -D, --database=VALUE       Database to use
  -i, --ignore-unsupported-db-versions
                             Ignore unsupported WordPress database versions
```
