### PR TITLE
Support specifying TLS versions

### DIFF
--- a/Goodbye.WordPress/ConnectionStringBuilder.cs
+++ b/Goodbye.WordPress/ConnectionStringBuilder.cs
@@ -79,6 +79,12 @@ namespace Goodbye.WordPress
             set => this[nameof(Database)] = value;
         }
 
+        public string? TlsVersion
+        {
+            get => this[nameof(TlsVersion)];
+            set => this[nameof(TlsVersion)] = "TLS " + value;
+        }
+
 
         static bool KeyEquals(string a, string b)
             => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
MySqlConnector had a bug due to which we had to specify TLS version to create successful connections.
reference mysql-net/MySqlConnector#1074 

Otherwise, we used to get following error,

    Unhandled exception ConnectionFailedException: "The collection already contains item with same key 'net.transport''"
     ---> System.InvalidOperationException: "The collection already contains item with same key 'net.transport''"

That bug is fixed with https://github.com/mysql-net/MySqlConnector/releases/tag/2.0.0

However, it's good to have the TLS Version support. :)

API call example,

    var exporter = WordPressExporter.Create(
    postReader: new MysqlPostReader(new ConnectionStringBuilder
    {
      Host = "localhost",
      Username = "user",
      Password = "***",
      Database = "wordpressdb",
      TlsVersion = "1.2"               // new addition
    }),
    contentOutputDirectory: "exported-posts",
    archiveOutputFilePath: "exported-posts/archive.json",

    // And now the delegate...
    @delegate: new CustomExporterDelegate());