### PR TITLE
Include posts with empty tags and support multiple categories

### DIFF
--- a/Goodbye.WordPress/MysqlPostReader.cs
+++ b/Goodbye.WordPress/MysqlPostReader.cs
@@ -106,25 +106,29 @@ namespace Goodbye.WordPress
                     p.post_date_gmt AS UtcDate,
                     p.post_name AS Name,
                     p.post_title AS Title,
-                    c.name AS Category,
-                    GROUP_CONCAT(
-                        DISTINCT t.name
-                        SEPARATOR ';') AS Tags,
+                    COALESCE(
+                        GROUP_CONCAT(DISTINCT c.name SEPARATOR ';'), 
+                        'NULL'
+                    ) AS Category, 
+                    COALESCE(
+                        GROUP_CONCAT(DISTINCT t.name SEPARATOR ';'), 
+                        'NULL'
+                    ) AS Tags, 
                     p.post_content AS Content
                 FROM wp_posts p
-                JOIN wp_term_relationships cr
+                LEFT JOIN wp_term_relationships cr
                     ON (p.id = cr.object_id)
-                JOIN wp_term_taxonomy ct
+                LEFT JOIN wp_term_taxonomy ct
                     ON (ct.term_taxonomy_id = cr.term_taxonomy_id
                         AND ct.taxonomy = 'category')
-                JOIN wp_terms c
+                LEFT JOIN wp_terms c
                     ON (ct.term_id = c.term_id)
-                JOIN wp_term_relationships tr
+                LEFT JOIN wp_term_relationships tr
                     ON (p.id = tr.object_id)
-                JOIN wp_term_taxonomy tt
+                LEFT JOIN wp_term_taxonomy tt
                     ON (tt.term_taxonomy_id = tr.term_taxonomy_id
                         AND tt.taxonomy = 'post_tag')
-                JOIN wp_terms t
+                LEFT JOIN wp_terms t
                     ON (tt.term_id = t.term_id)
                 WHERE
                     p.post_type = 'post'


### PR DESCRIPTION
_copied from original commit's log_

**Test plan**
Testing with a sample wordpress database with about 3k posts,

Row count for original query,

    > SELECT Count(*)
    FROM
    (
      Original_Query
    ) WP_Db_Original;
    +----------+
    | Count(*) |
    +----------+
    |      262 |
    +----------+
    1 row in set (3.15 sec)

Row count using the updated query,

    SELECT Count(*)
    FROM
    (
      Updated_Query_Supporting_Empty_Tags
    ) WP_Emp_Tags;

    +----------+
    | Count(*) |
    +----------+
    |      845 |
    +----------+
    1 row in set (4 min 33.66 sec)

That's pretty much it.