### PR TITLE
Merge Categories into Tags

### DIFF
--- a/Goodbye.WordPress/MysqlPostReader.cs
+++ b/Goodbye.WordPress/MysqlPostReader.cs
@@ -109,13 +109,13 @@ namespace Goodbye.WordPress
                     p.post_name AS Name,
                     p.post_title AS Title,
                     COALESCE(
-                        GROUP_CONCAT(DISTINCT c.name SEPARATOR ';'), 
+                        GROUP_CONCAT(DISTINCT c.name SEPARATOR ';'),
                         'NULL'
-                    ) AS Category, 
+                    ) AS Category,
                     COALESCE(
-                        GROUP_CONCAT(DISTINCT t.name SEPARATOR ';'), 
+                        GROUP_CONCAT(DISTINCT t.name SEPARATOR ';'),
                         'NULL'
-                    ) AS Tags, 
+                    ) AS Tags,
                     p.post_content AS Content
                 FROM wp_posts p
                 LEFT JOIN wp_term_relationships cr
@@ -135,7 +135,6 @@ namespace Goodbye.WordPress
                 WHERE
                     p.post_type = 'post'
                 GROUP BY p.id
-                LIMIT 100
             ", connection);
 
             var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -175,12 +174,10 @@ namespace Goodbye.WordPress
                     reader.GetString("Category")
                         .Split(";")
                         .Select(c => c.Trim().ToLowerInvariant())
-                        .Distinct()
                         .ToImmutableList(),
                     reader.GetString("Tags")
                         .Split(";")
                         .Select(t => t.Trim().ToLowerInvariant())
-                        .Distinct()
                         .ToImmutableList(),
                     reader.GetString("Content"),
                     originalUrl is null

--- a/Goodbye.WordPress/MysqlPostReader.cs
+++ b/Goodbye.WordPress/MysqlPostReader.cs
@@ -135,6 +135,7 @@ namespace Goodbye.WordPress
                 WHERE
                     p.post_type = 'post'
                 GROUP BY p.id
+                LIMIT 100
             ", connection);
 
             var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -171,13 +172,11 @@ namespace Goodbye.WordPress
                     updatedDate,
                     postName,
                     reader.GetString("Title"),
-                    reader.GetString("Category") is string category &&
-                        !string.Equals(
-                            category,
-                            "uncategorized",
-                            StringComparison.OrdinalIgnoreCase)
-                        ? category
-                        : null,
+                    reader.GetString("Category")
+                        .Split(";")
+                        .Select(c => c.Trim().ToLowerInvariant())
+                        .Distinct()
+                        .ToImmutableList(),
                     reader.GetString("Tags")
                         .Split(";")
                         .Select(t => t.Trim().ToLowerInvariant())

--- a/Goodbye.WordPress/Post.cs
+++ b/Goodbye.WordPress/Post.cs
@@ -14,7 +14,7 @@ namespace Goodbye.WordPress
         DateTimeOffset? Updated,
         string Name,
         string Title,
-        string? Category,
+        ImmutableList<string> Categories,
         ImmutableList<string> Tags,
         string Content,
         ImmutableList<string> RedirectFrom,

--- a/Goodbye.WordPress/WordPressExporterDelegate.cs
+++ b/Goodbye.WordPress/WordPressExporterDelegate.cs
@@ -244,18 +244,20 @@ namespace Goodbye.WordPress
             AddDateField(nameof(Post.Published), post.Published);
             AddDateField(nameof(Post.Updated), post.Updated);
 
-            var finalTagsNode = new YamlSequenceNode(
-                post.Tags.Select(tag => new YamlScalarNode(tag))
-                .Union(post.Categories.Select(category => new YamlScalarNode(category)))
-                .Where(ct => ct.Value != "null" && ct.Value != "uncategorized"));
 
-            if (finalTagsNode.Children.Count == 0)
-                finalTagsNode = new YamlSequenceNode(
-                    new YamlScalarNode("untagged"));
+            var finalTags = post.Tags
+                .Union(post.Categories)
+                .Where(ct => ct != "null" && ct != "uncategorized");
+
+            if (finalTags.Count() == 0)
+                finalTags = new List<string>() { "untagged" };
 
             rootNode.Add(
                 nameof(Post.Tags),
-                finalTagsNode);
+                new YamlSequenceNode(
+                    finalTags.Select(tag => new YamlScalarNode(tag))
+                )
+            );
 
             if (post.Status != "publish")
                 rootNode.Add("Excluded", "true");

--- a/Goodbye.WordPress/WordPressExporterDelegate.cs
+++ b/Goodbye.WordPress/WordPressExporterDelegate.cs
@@ -244,16 +244,18 @@ namespace Goodbye.WordPress
             AddDateField(nameof(Post.Published), post.Published);
             AddDateField(nameof(Post.Updated), post.Updated);
 
-            if (!string.IsNullOrEmpty(post.Category))
-                rootNode.Add(
-                    nameof(Post.Category),
-                    post.Category);
+            var finalTagsNode = new YamlSequenceNode(
+                post.Tags.Select(tag => new YamlScalarNode(tag))
+                .Union(post.Categories.Select(category => new YamlScalarNode(category)))
+                .Where(ct => ct.Value != "null" && ct.Value != "uncategorized"));
 
-            if (post.Tags.Count > 0)
-                rootNode.Add(
-                    nameof(Post.Tags),
-                    new YamlSequenceNode(
-                        post.Tags.Select(tag => new YamlScalarNode(tag))));
+            if (finalTagsNode.Children.Count == 0)
+                finalTagsNode = new YamlSequenceNode(
+                    new YamlScalarNode("untagged"));
+
+            rootNode.Add(
+                nameof(Post.Tags),
+                finalTagsNode);
 
             if (post.Status != "publish")
                 rootNode.Add("Excluded", "true");


### PR DESCRIPTION
In my statiq blog,  I merge categories into tags.

In summary, following changes made,
- category is a collection, not a single item
- categories are in lower case similar to tags
- returns distinct items
- for the ones where no categories and no tags found mark them as untagged so
  that they are easy to find and fix later

If you are actually utilizing categories from YAML output, please feel free to disregard this PR.

However,  this might still be useful,
- category is a collection, not a single item

**Test Plan**

    $ dotnet build
    ... ...
    Build succeeded.
        0 Warning(s)
        0 Error(s)

    Time Elapsed 00:00:08.71

Tested YAML output for 200 files.